### PR TITLE
Add initial benchmarks

### DIFF
--- a/rate_limited_issuance.go
+++ b/rate_limited_issuance.go
@@ -165,9 +165,9 @@ func encryptOriginTokenRequest(nameKey EncapKey, tokenKeyID uint8, blindedMessag
 	input := tokenRequest.Marshal()
 
 	aad := b.BytesOrPanic()
+
 	ct := context.Seal(aad, input)
 	encryptedTokenRequest := append(enc, ct...)
-
 	secret := context.Export([]byte("TokenResponse"), nameKey.suite.AEAD.KeySize())
 
 	return issuerKeyID[:], encryptedTokenRequest, secret, nil
@@ -518,7 +518,8 @@ func (i RateLimitedIssuer) Evaluate(req *RateLimitedTokenRequest) ([]byte, []byt
 		return nil, nil, err
 	}
 
-	enc := req.EncryptedTokenRequest[0:i.nameKey.suite.KEM.PublicKeySize()]
+	enc := make([]byte, i.nameKey.suite.KEM.PublicKeySize())
+	copy(enc, req.EncryptedTokenRequest[0:i.nameKey.suite.KEM.PublicKeySize()])
 	salt := append(append(enc, responseNonce...))
 
 	// Derive encryption secrets


### PR DESCRIPTION
The code currently bakes in ECDSA for the rate-limited variant, so we're stuck measuring that for now. We need to generalize this so that it can be configured with EdDSA or ECDSA. 

```
$ go test -bench=.   
goos: darwin
goarch: amd64
pkg: github.com/cloudflare/pat-go
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkPublicTokenRoundTrip/Basic_Public_Client_Blind-12         	1000000000	         0.0001337 ns/op
BenchmarkPublicTokenRoundTrip/Basic_Public_Client_Evaluate-12      	1000000000	         0.001509 ns/op
BenchmarkPublicTokenRoundTrip/Basic_Public_Client_Finalize-12      	1000000000	         0.0001110 ns/op
BenchmarkRateLimitedTokenRoundTrip/Rate-Limited_Client_Blind-12    	1000000000	         0.01257 ns/op
BenchmarkRateLimitedTokenRoundTrip/Rate-Limited_Issuer_Evaluate-12 	1000000000	         0.01139 ns/op
BenchmarkRateLimitedTokenRoundTrip/Rate-Limited_Attester_Index-12  	1000000000	         0.006364 ns/op
BenchmarkRateLimitedTokenRoundTrip/Rate-Limited_Client_Finalize-12 	1000000000	         0.0001215 ns/op
```