### PR TITLE
Move request_key and token_key_id around in the issuance flow

### DIFF
--- a/rate_limited_issuance.go
+++ b/rate_limited_issuance.go
@@ -38,8 +38,8 @@ func (r *InnerTokenRequest) Marshal() []byte {
 	}
 
 	b := cryptobyte.NewBuilder(nil)
-	b.AddBytes(r.blindedMsg)
 	b.AddUint8(r.tokenKeyId)
+	b.AddBytes(r.blindedMsg)
 	b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
 		b.AddBytes([]byte(r.paddedOrigin))
 	})
@@ -51,8 +51,7 @@ func (r *InnerTokenRequest) Marshal() []byte {
 func (r *InnerTokenRequest) Unmarshal(data []byte) bool {
 	s := cryptobyte.String(data)
 
-	if !s.ReadBytes(&r.blindedMsg, 256) ||
-		!s.ReadUint8(&r.tokenKeyId) {
+	if !s.ReadUint8(&r.tokenKeyId) || !s.ReadBytes(&r.blindedMsg, 256) {
 		return false
 	}
 

--- a/rate_limited_issuance_test.go
+++ b/rate_limited_issuance_test.go
@@ -224,7 +224,7 @@ type rawOriginEncryptionTestVector struct {
 	OriginNameKey         string      `json:"issuer_encap_key"`
 	TokenType             uint16      `json:"token_type"`
 	OriginNameKeyID       string      `json:"issuer_encap_key_id"`
-	IndexRequest          string      `json:"request_key"`
+	RequestKey            string      `json:"request_key"`
 	TokenKeyID            uint8       `json:"token_key_id"`
 	BlindMessage          string      `json:"blinded_msg"`
 	OriginName            string      `json:"origin_name"`
@@ -240,7 +240,7 @@ type originEncryptionTestVector struct {
 	nameKeySeed           []byte
 	nameKey               PrivateEncapKey
 	tokenType             uint16
-	indexRequest          []byte
+	requestKey            []byte
 	tokenKeyID            uint8
 	blindMessage          []byte
 	issuerKeyID           []byte
@@ -278,7 +278,7 @@ func (etv originEncryptionTestVector) MarshalJSON() ([]byte, error) {
 		OriginNameKeySeed:     mustHex(etv.nameKeySeed),
 		OriginNameKey:         mustHex(etv.nameKey.Public().Marshal()),
 		TokenType:             etv.tokenType,
-		IndexRequest:          mustHex(etv.indexRequest),
+		RequestKey:            mustHex(etv.requestKey),
 		TokenKeyID:            etv.tokenKeyID,
 		BlindMessage:          mustHex(etv.blindMessage),
 		OriginNameKeyID:       mustHex(etv.issuerKeyID),
@@ -316,7 +316,7 @@ func (etv *originEncryptionTestVector) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	etv.nameKey = nameKey
-	etv.indexRequest = mustUnhex(nil, raw.IndexRequest)
+	etv.requestKey = mustUnhex(nil, raw.RequestKey)
 	etv.tokenKeyID = raw.TokenKeyID
 	etv.blindMessage = mustUnhex(nil, raw.BlindMessage)
 	etv.issuerKeyID = mustUnhex(nil, raw.OriginNameKeyID)
@@ -336,15 +336,15 @@ func generateOriginEncryptionTestVector(t *testing.T, kemID hpke.KEMID, kdfID hp
 	}
 
 	// Generate random token and index requests
-	indexRequest := make([]byte, 49)
-	rand.Reader.Read(indexRequest)
+	requestKey := make([]byte, 49)
+	rand.Reader.Read(requestKey)
 	tokenKeyIDBuf := []byte{0x00}
 	rand.Reader.Read(tokenKeyIDBuf)
 	blindMessage := make([]byte, 256)
 	rand.Reader.Read(blindMessage)
 
 	originName := "test.example"
-	_, encryptedTokenRequest, secret, err := encryptOriginTokenRequest(nameKey.Public(), tokenKeyIDBuf[0], blindMessage, indexRequest, originName)
+	_, encryptedTokenRequest, secret, err := encryptOriginTokenRequest(nameKey.Public(), tokenKeyIDBuf[0], blindMessage, requestKey, originName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -360,7 +360,7 @@ func generateOriginEncryptionTestVector(t *testing.T, kemID hpke.KEMID, kdfID hp
 		nameKey:               nameKey,
 		issuerKeyID:           issuerKeyID[:],
 		tokenType:             RateLimitedTokenType,
-		indexRequest:          indexRequest,
+		requestKey:            requestKey,
 		tokenKeyID:            tokenKeyIDBuf[0],
 		blindMessage:          blindMessage,
 		originName:            originName,
@@ -387,7 +387,7 @@ func verifyOriginEncryptionTestVector(t *testing.T, vector originEncryptionTestV
 		t.Fatal(err)
 	}
 
-	originTokenRequest, _, err := decryptOriginTokenRequest(privateNameKey, vector.tokenKeyID, vector.encryptedTokenRequest)
+	originTokenRequest, _, err := decryptOriginTokenRequest(privateNameKey, vector.requestKey, vector.encryptedTokenRequest)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/rate_limited_issuance_test.go
+++ b/rate_limited_issuance_test.go
@@ -146,7 +146,11 @@ func TestRateLimitedIssuanceRoundTrip(t *testing.T) {
 
 	publicKeyEnc := elliptic.MarshalCompressed(curve, client.secretKey.PublicKey.X, client.secretKey.PublicKey.Y)
 
-	expectedIndexKey, err := ecdsa.BlindPublicKey(curve, &client.secretKey.PublicKey, originIndexKey)
+	b := cryptobyte.NewBuilder(nil)
+	b.AddUint16(RateLimitedTokenType)
+	b.AddBytes([]byte("IssuerBlind"))
+	ctx := b.BytesOrPanic()
+	expectedIndexKey, err := ecdsa.BlindPublicKeyWithContext(curve, &client.secretKey.PublicKey, originIndexKey, ctx)
 	if err != nil {
 		t.Error(err)
 	}
@@ -171,7 +175,7 @@ func TestRateLimitedIssuanceRoundTrip(t *testing.T) {
 		t.Error(err)
 	}
 
-	b := cryptobyte.NewBuilder(nil)
+	b = cryptobyte.NewBuilder(nil)
 	b.AddUint16(RateLimitedTokenType)
 	b.AddBytes(nonce)
 	context := sha256.Sum256(challenge)


### PR DESCRIPTION
See [the corresponding spec PR](https://github.com/tfpauly/privacy-proxy/pull/220) for context.