### PR TITLE
Add benchmark scripts and update some internals 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ This will produce several JSON files:
 
 Examples for generating and verifying the test vectors can be found [in the Makefile](https://github.com/cloudflare/pat-go/blob/main/Makefile).
 
-## Benchmarks
+## PerformanceBenchmarks
 
-To compute benchmarks, run:
+To compute performance benchmarks, run:
 
 ```
 $ go test -bench=.
@@ -38,13 +38,17 @@ goos: darwin
 goarch: amd64
 pkg: github.com/cloudflare/pat-go
 cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
-BenchmarkPublicTokenRoundTrip/Basic_Public_Client_Blind-12         	1000000000	         0.0001171 ns/op
-BenchmarkPublicTokenRoundTrip/Basic_Public_Client_Evaluate-12      	1000000000	         0.001317 ns/op
-BenchmarkPublicTokenRoundTrip/Basic_Public_Client_Finalize-12      	1000000000	         0.0001098 ns/op
-BenchmarkRateLimitedTokenRoundTrip/Rate-Limited_Client_Blind-12    	1000000000	         0.01648 ns/op
-BenchmarkRateLimitedTokenRoundTrip/Rate-Limited_Issuer_Evaluate-12 	1000000000	         0.01106 ns/op
-BenchmarkRateLimitedTokenRoundTrip/Rate-Limited_Attester_Index-12  	1000000000	         0.006282 ns/op
-BenchmarkRateLimitedTokenRoundTrip/Rate-Limited_Client_Finalize-12 	1000000000	         0.0001152 ns/op
+BenchmarkPublicTokenRoundTrip/ClientRequest-12         	1000000000	         0.0001208 ns/op
+BenchmarkPublicTokenRoundTrip/IssuerEvaluate-12        	1000000000	         0.001364 ns/op
+BenchmarkPublicTokenRoundTrip/ClientFinalize-12        	1000000000	         0.0001122 ns/op
+BenchmarkRateLimitedTokenRoundTrip/ClientRequest-12    	1000000000	         0.01773 ns/op
+BenchmarkRateLimitedTokenRoundTrip/IssuerEvaluate-12   	1000000000	         0.01098 ns/op
+BenchmarkRateLimitedTokenRoundTrip/AttesterProcess-12  	1000000000	         0.006127 ns/op
+BenchmarkRateLimitedTokenRoundTrip/ClientFinalize-12   	1000000000	         0.0001258 ns/op
 PASS
-ok  	github.com/cloudflare/pat-go	0.749s
+ok  	github.com/cloudflare/pat-go	0.685s
 ```
+
+### Formatting Results
+
+TODO(caw): describe how to invoke the formatting script

--- a/README.md
+++ b/README.md
@@ -51,4 +51,23 @@ ok  	github.com/cloudflare/pat-go	0.685s
 
 ### Formatting Results
 
-TODO(caw): describe how to invoke the formatting script
+To produce a LaTeX table of the performance benchmarks, run the [scripts/format_benchmarks.py](format_benchmarks.py) script on the benchmark output, like so:
+
+```
+$ go test -bench=. | python3 scripts/format_benchmarks.py
+\begin{table}[ht!]
+\label{tab:bench-computation-overhead}
+\caption{Computation cost for basic and rate-limited issuance protocols
+\begin{tabular}{|l|c|}
+{\bf Operation} & {\bf Time (ns/op)} \hline
+\hline
+  Basic Client Request & $0.0001206 $ \ \hline
+  Basic Issuer Evaluate & $0.001389 $ \ \hline
+  Basic Client Finalize & $0.0001130 $ \ \hline
+  Rate-Limited Client Request & $0.01281 $ \ \hline
+  Rate-Limited Issuer Evaluate & $0.01089 $ \ \hline
+  Rate-Limited Attester Process & $0.006324 $ \ \hline
+  Rate-Limited Client Finalize & $0.0001205 $ \ \hline
+\end{tabular}
+\end{table}
+```

--- a/basic_public_issuance_test.go
+++ b/basic_public_issuance_test.go
@@ -319,7 +319,7 @@ func BenchmarkPublicTokenRoundTrip(b *testing.B) {
 
 	var err error
 	var requestState BasicPublicTokenRequestState
-	b.Run("Basic Public Client Blind", func(b *testing.B) {
+	b.Run("ClientRequest", func(b *testing.B) {
 		nonce := make([]byte, 32)
 		rand.Reader.Read(nonce)
 
@@ -330,14 +330,14 @@ func BenchmarkPublicTokenRoundTrip(b *testing.B) {
 	})
 
 	var blindedSignature []byte
-	b.Run("Basic Public Client Evaluate", func(b *testing.B) {
+	b.Run("IssuerEvaluate", func(b *testing.B) {
 		blindedSignature, err = issuer.Evaluate(requestState.Request())
 		if err != nil {
 			b.Error(err)
 		}
 	})
 
-	b.Run("Basic Public Client Finalize", func(b *testing.B) {
+	b.Run("ClientFinalize", func(b *testing.B) {
 		_, err := requestState.FinalizeToken(blindedSignature)
 		if err != nil {
 			b.Error(err)

--- a/scripts/format_benchmarks.py
+++ b/scripts/format_benchmarks.py
@@ -37,11 +37,11 @@ for line in sys.stdin:
 
 print("\\begin{table}[ht!]")
 print("\\label{tab:bench-computation-overhead}")
-print("\\caption{Computation cost for basic and rate-limited issuance protocols")
-print("\\begin{tabular}{|l|c|}")
-print("{\\bf Operation} & {\\bf Time (ns/op)} \hline")
+print("\\caption{Computation cost for basic and rate-limited issuance protocols}")
+print("\\begin{tabular}{| l | c |}")
 print("\hline")
+print("\\textbf{Operation} & \\textbf{Time (ns/op)} \\\\ \hline")
 for name in orderedNames:
-    print("  %s & $%s$ \\ \hline" % (name, costs[name]))
+    print("  %s & $%s$ \\\\ \hline" % (name, costs[name]))
 print("\end{tabular}")
 print("\end{table}")

--- a/scripts/format_benchmarks.py
+++ b/scripts/format_benchmarks.py
@@ -1,0 +1,45 @@
+import sys
+
+nameMap = {
+    "BenchmarkPublicTokenRoundTrip/ClientRequest": "Basic Client Request",
+    "BenchmarkPublicTokenRoundTrip/IssuerEvaluate": "Basic Issuer Evaluate",
+    "BenchmarkPublicTokenRoundTrip/ClientFinalize": "Basic Client Finalize",
+    "BenchmarkRateLimitedTokenRoundTrip/ClientRequest": "Rate-Limited Client Request",
+    "BenchmarkRateLimitedTokenRoundTrip/IssuerEvaluate": "Rate-Limited Issuer Evaluate",
+    "BenchmarkRateLimitedTokenRoundTrip/AttesterProcess": "Rate-Limited Attester Process",
+    "BenchmarkRateLimitedTokenRoundTrip/ClientFinalize": "Rate-Limited Client Finalize",
+}
+
+orderedNames = [
+    "Basic Client Request",
+    "Basic Issuer Evaluate",
+    "Basic Client Finalize",
+    "Rate-Limited Client Request",
+    "Rate-Limited Issuer Evaluate",
+    "Rate-Limited Attester Process",
+    "Rate-Limited Client Finalize",
+]
+
+def mapName(name):
+    for key in nameMap:
+        if name.startswith(key):
+            return nameMap[key]
+    raise Exception("Unknown operation", name)
+
+costs = {}
+for line in sys.stdin:
+    if line.startswith("Benchmark"):
+        line = line.strip().split("\t")
+        name, cost = mapName(line[0].strip()), line[2].strip().replace("ns/op", "")
+        costs[name] = cost
+
+print("\\begin{table}[ht!]")
+print("\\label{tab:bench-computation-overhead}")
+print("\\caption{Computation cost for basic and rate-limited issuance protocols")
+print("\\begin{tabular}{|l|c|}")
+print("{\\bf Operation} & {\\bf Time (ns/op)} \hline")
+print("\hline")
+for name in orderedNames:
+    print("  %s & $%s$ \\ \hline" % (name, costs[name]))
+print("\end{tabular}")
+print("\end{table}")

--- a/scripts/format_benchmarks.py
+++ b/scripts/format_benchmarks.py
@@ -5,8 +5,9 @@ nameMap = {
     "BenchmarkPublicTokenRoundTrip/IssuerEvaluate": "Basic Issuer Evaluate",
     "BenchmarkPublicTokenRoundTrip/ClientFinalize": "Basic Client Finalize",
     "BenchmarkRateLimitedTokenRoundTrip/ClientRequest": "Rate-Limited Client Request",
+    "BenchmarkRateLimitedTokenRoundTrip/AttesterRequest": "Rate-Limited Attester Request",
     "BenchmarkRateLimitedTokenRoundTrip/IssuerEvaluate": "Rate-Limited Issuer Evaluate",
-    "BenchmarkRateLimitedTokenRoundTrip/AttesterProcess": "Rate-Limited Attester Process",
+    "BenchmarkRateLimitedTokenRoundTrip/AttesterEvaluate": "Rate-Limited Attester Evaluate",
     "BenchmarkRateLimitedTokenRoundTrip/ClientFinalize": "Rate-Limited Client Finalize",
 }
 
@@ -15,8 +16,9 @@ orderedNames = [
     "Basic Issuer Evaluate",
     "Basic Client Finalize",
     "Rate-Limited Client Request",
+    "Rate-Limited Attester Request",
     "Rate-Limited Issuer Evaluate",
-    "Rate-Limited Attester Process",
+    "Rate-Limited Attester Evaluate",
     "Rate-Limited Client Finalize",
 ]
 


### PR DESCRIPTION
The internal updates add a rate-limited Attester type with specific functions for the things it does in the issuance protocol, including client request verification and issuer response processing. 