### PR TITLE
Add attester invariant checks

### DIFF
--- a/token_request_test.go
+++ b/token_request_test.go
@@ -16,7 +16,7 @@ func TestRequestMarshal(t *testing.T) {
 	curve := elliptic.P384()
 	secretKey, err := ecdsa.GenerateKey(curve, rand.Reader)
 	blindKey, err := ecdsa.GenerateKey(curve, rand.Reader)
-	client := CreateRateLimitedClientFromSecret(secretKey.D.Bytes())
+	client := NewRateLimitedClientFromSecret(secretKey.D.Bytes())
 
 	challenge := make([]byte, 32)
 	rand.Reader.Read(challenge)


### PR DESCRIPTION
This pulls the check from pat-app into the core library. The importance of the check is described [in this issue](https://github.com/ietf-wg-privacypass/draft-ietf-privacypass-rate-limit-tokens/issues/6).