### PR TITLE
Benchmark loops

### DIFF
--- a/basic_public_issuance_test.go
+++ b/basic_public_issuance_test.go
@@ -320,27 +320,33 @@ func BenchmarkPublicTokenRoundTrip(b *testing.B) {
 	var err error
 	var requestState BasicPublicTokenRequestState
 	b.Run("ClientRequest", func(b *testing.B) {
-		nonce := make([]byte, 32)
-		rand.Reader.Read(nonce)
+		for n := 0; n < b.N; n++ {
+			nonce := make([]byte, 32)
+			rand.Reader.Read(nonce)
 
-		requestState, err = client.CreateTokenRequest(challenge, nonce, tokenKeyID, tokenPublicKey)
-		if err != nil {
-			b.Error(err)
+			requestState, err = client.CreateTokenRequest(challenge, nonce, tokenKeyID, tokenPublicKey)
+			if err != nil {
+				b.Error(err)
+			}
 		}
 	})
 
 	var blindedSignature []byte
 	b.Run("IssuerEvaluate", func(b *testing.B) {
-		blindedSignature, err = issuer.Evaluate(requestState.Request())
-		if err != nil {
-			b.Error(err)
+		for n := 0; n < b.N; n++ {
+			blindedSignature, err = issuer.Evaluate(requestState.Request())
+			if err != nil {
+				b.Error(err)
+			}
 		}
 	})
 
 	b.Run("ClientFinalize", func(b *testing.B) {
-		_, err := requestState.FinalizeToken(blindedSignature)
-		if err != nil {
-			b.Error(err)
+		for n := 0; n < b.N; n++ {
+			_, err := requestState.FinalizeToken(blindedSignature)
+			if err != nil {
+				b.Error(err)
+			}
 		}
 	})
 }

--- a/rate_limited_issuance_test.go
+++ b/rate_limited_issuance_test.go
@@ -801,42 +801,52 @@ func BenchmarkRateLimitedTokenRoundTrip(b *testing.B) {
 
 	var requestState RateLimitedTokenRequestState
 	b.Run("ClientRequest", func(b *testing.B) {
-		nonce := make([]byte, 32)
-		rand.Reader.Read(nonce)
-		requestState, err = client.CreateTokenRequest(challenge, nonce, blindKey.D.Bytes(), issuer.TokenKeyID(), issuer.TokenKey(), testOrigin, issuer.NameKey())
-		if err != nil {
-			b.Error(err)
+		for n := 0; n < b.N; n++ {
+			nonce := make([]byte, 32)
+			rand.Reader.Read(nonce)
+			requestState, err = client.CreateTokenRequest(challenge, nonce, blindKey.D.Bytes(), issuer.TokenKeyID(), issuer.TokenKey(), testOrigin, issuer.NameKey())
+			if err != nil {
+				b.Error(err)
+			}
 		}
 	})
 
 	b.Run("AttesterRequest", func(b *testing.B) {
-		err = attester.VerifyRequest(*requestState.Request(), blindKey, &secretKey.PublicKey, anonymousOriginID)
-		if err != nil {
-			b.Error(err)
+		for n := 0; n < b.N; n++ {
+			err = attester.VerifyRequest(*requestState.Request(), blindKey, &secretKey.PublicKey, anonymousOriginID)
+			if err != nil {
+				b.Error(err)
+			}
 		}
 	})
 
 	var blindedSignature []byte
 	var blindedPublicKey []byte
 	b.Run("IssuerEvaluate", func(b *testing.B) {
-		blindedSignature, blindedPublicKey, err = issuer.Evaluate(requestState.Request())
-		if err != nil {
-			b.Error(err)
+		for n := 0; n < b.N; n++ {
+			blindedSignature, blindedPublicKey, err = issuer.Evaluate(requestState.Request())
+			if err != nil {
+				b.Error(err)
+			}
 		}
 	})
 
 	b.Run("AttesterEvaluate", func(b *testing.B) {
-		publicKeyEnc := elliptic.MarshalCompressed(curve, client.secretKey.PublicKey.X, client.secretKey.PublicKey.Y)
-		_, err = attester.FinalizeIndex(publicKeyEnc, blindKey.D.Bytes(), blindedPublicKey, anonymousOriginID)
-		if err != nil {
-			b.Error(err)
+		for n := 0; n < b.N; n++ {
+			publicKeyEnc := elliptic.MarshalCompressed(curve, client.secretKey.PublicKey.X, client.secretKey.PublicKey.Y)
+			_, err = attester.FinalizeIndex(publicKeyEnc, blindKey.D.Bytes(), blindedPublicKey, anonymousOriginID)
+			if err != nil {
+				b.Error(err)
+			}
 		}
 	})
 
 	b.Run("ClientFinalize", func(b *testing.B) {
-		_, err := requestState.FinalizeToken(blindedSignature)
-		if err != nil {
-			b.Error(err)
+		for n := 0; n < b.N; n++ {
+			_, err := requestState.FinalizeToken(blindedSignature)
+			if err != nil {
+				b.Error(err)
+			}
 		}
 	})
 }


### PR DESCRIPTION
The sub-benchmarks used in BenchmarkPublicTokenRoundTrip and BenchmarkRateLimitedTokenRoundTrip were ignoring the b.N parameter and were executing the benchmark only once, which created incorrect results. See attached screenshot; running the benchmark with 100x or 1000x would create different estimate of the ns/op by correspondingly a factor of 100. 
![Screen Shot 2022-10-24 at 1 48 06 PM](https://user-images.githubusercontent.com/1090209/197605771-e92aa379-2c1b-4dfe-9b69-fb04bccfe080.png)

This pull request adds the necessary loops and produces correct benchmark values. The second screenshot, after this change, gives more realistic timing values and they do not change based on the number 
of times the test is run. 
![Screen Shot 2022-10-24 at 2 05 35 PM](https://user-images.githubusercontent.com/1090209/197605803-e84c3260-cd36-42b6-a575-9430147f4e09.png)
